### PR TITLE
Updated parameter block for ACT-lite.

### DIFF
--- a/act_dr6_cmbonly/act_dr6_cmbonly.py
+++ b/act_dr6_cmbonly/act_dr6_cmbonly.py
@@ -30,16 +30,16 @@ class ACTDR6CMBonly(InstallableLikelihood):
 
     params: dict = {
         "A_act": {
-          "prior": { "min" : 0.5, "max" : 1.5 },
-          "ref": { "dist": "norm", "loc" : 1.0, "scale": 0.1 },
-          "proposal" : 0.003,
-          "latex" : "A_{\\rm ACT}"
+          "prior": {"min": 0.5, "max": 1.5},
+          "ref": {"dist": "norm", "loc": 1.0, "scale": 0.1},
+          "proposal": 0.003,
+          "latex": "A_{\\rm ACT}"
         },
         "P_act": {
-          "prior": { "min" : 0.9, "max" : 1.1 },
-          "ref": { "dist": "norm", "loc" : 1.0, "scale": 0.1 },
-          "proposal" : 0.03,
-          "latex" : "p_{\\rm ACT}"
+          "prior": {"min": 0.9, "max": 1.1},
+          "ref": {"dist": "norm", "loc": 1.0, "scale": 0.1},
+          "proposal": 0.03,
+          "latex": "p_{\\rm ACT}"
         }
     }
 

--- a/act_dr6_cmbonly/act_dr6_cmbonly.py
+++ b/act_dr6_cmbonly/act_dr6_cmbonly.py
@@ -26,7 +26,7 @@ class ACTDR6CMBonly(InstallableLikelihood):
         "TE": [600, 6500],
         "EE": [600, 6500]
     }
-    lmax_theory: Optional[int] = None
+    lmax_theory: int = 9000
 
     params: dict = {
         "A_act": {

--- a/act_dr6_cmbonly/act_dr6_cmbonly.py
+++ b/act_dr6_cmbonly/act_dr6_cmbonly.py
@@ -28,6 +28,21 @@ class ACTDR6CMBonly(InstallableLikelihood):
     }
     lmax_theory: Optional[int] = None
 
+    params: dict = {
+        "A_act": {
+          "prior": { "min" : 0.5, "max" : 1.5 },
+          "ref": { "dist": "norm", "loc" : 1.0, "scale": 0.1 },
+          "proposal" : 0.003,
+          "latex" : "A_{\\rm ACT}"
+        },
+        "P_act": {
+          "prior": { "min" : 0.9, "max" : 1.1 },
+          "ref": { "dist": "norm", "loc" : 1.0, "scale": 0.1 },
+          "proposal" : 0.03,
+          "latex" : "p_{\\rm ACT}"
+        }
+    }
+
     def initialize(self):
         if self.packages_path is None:
             self.data_folder = os.path.join(

--- a/act_dr6_cmbonly/act_dr6_cmbonly.py
+++ b/act_dr6_cmbonly/act_dr6_cmbonly.py
@@ -1,6 +1,5 @@
 import os
 import numpy as np
-from typing import Optional
 from cobaya.likelihoods.base_classes import InstallableLikelihood
 
 

--- a/act_dr6_cmbonly/tests/test_act.py
+++ b/act_dr6_cmbonly/tests/test_act.py
@@ -70,7 +70,7 @@ def test_TTTEEE():
     }
     model = get_model(info)
     loglikes = sum(model.loglikes()[0])
-    assert np.isclose(loglikes, -395.48, atol = 1e-2), \
+    assert np.isclose(loglikes, -395.48, atol=1e-2), \
         "TT/TE/EE log-posterior does not match."
 
 
@@ -91,7 +91,7 @@ def test_Planck():
     }
     model = get_model(info)
     loglikes = sum(model.loglikes()[0])
-    assert np.isclose(loglikes, -962.27, atol = 1e-2), \
+    assert np.isclose(loglikes, -962.27, atol=1e-2), \
         "ACT+Planck log-posterior does not match."
 
 

--- a/act_dr6_cmbonly/tests/test_act.py
+++ b/act_dr6_cmbonly/tests/test_act.py
@@ -70,7 +70,7 @@ def test_TTTEEE():
     }
     model = get_model(info)
     loglikes = sum(model.loglikes()[0])
-    assert np.isclose(loglikes, -395.48), \
+    assert np.isclose(loglikes, -395.48, atol = 1e-2), \
         "TT/TE/EE log-posterior does not match."
 
 
@@ -91,7 +91,7 @@ def test_Planck():
     }
     model = get_model(info)
     loglikes = sum(model.loglikes()[0])
-    assert np.isclose(loglikes, -962.27), \
+    assert np.isclose(loglikes, -962.27, atol = 1e-2), \
         "ACT+Planck log-posterior does not match."
 
 

--- a/yamls/likelihoods/act_lite.yaml
+++ b/yamls/likelihoods/act_lite.yaml
@@ -2,29 +2,3 @@ planck_2018_lowl.EE_sroll2: null
 
 act_dr6_cmbonly:
   stop_at_error: true
-  lmax_theory: 9000
-  ell_cuts:
-    TT: [600,6500]
-    TE: [600,6500]
-    EE: [600,6500]
-  params:
-    A_act:
-      prior:
-        min: 0.5
-        max: 1.5
-      ref:
-        dist: norm
-        loc: 1.0
-        scale: 0.01
-      proposal: 0.003
-      latex: A_{\rm ACT}
-    P_act:
-      prior:
-        min: 0.9
-        max: 1.1
-      ref:
-        dist: norm
-        loc: 1.0
-        scale: 0.01
-      proposal: 0.01
-      latex: p_{\rm ACT}

--- a/yamls/likelihoods/act_lite.yaml
+++ b/yamls/likelihoods/act_lite.yaml
@@ -1,12 +1,12 @@
 planck_2018_lowl.EE_sroll2: null
-act_dr6_cmbonly.ACTDR6CMBonly:
-  input_file: dr6_data_cmbonly.fits
+
+act_dr6_cmbonly:
+  stop_at_error: true
   lmax_theory: 9000
   ell_cuts:
-    TT: [600,8500]
-    TE: [600,8500]
-    EE: [600,8500]
-  stop_at_error: true
+    TT: [600,6500]
+    TE: [600,6500]
+    EE: [600,6500]
   params:
     A_act:
       prior:

--- a/yamls/likelihoods/p_act_lite.yaml
+++ b/yamls/likelihoods/p_act_lite.yaml
@@ -16,14 +16,14 @@ act_dr6_cmbonly.PlanckActCut:
         scale: 0.1
       latex: A_{\rm planck}
       proposal: 0.003
-act_dr6_cmbonly.ACTDR6CMBonly:
-  input_file: dr6_data_cmbonly.fits
+
+act_dr6_cmbonly:
+  stop_at_error: true
   lmax_theory: 9000
   ell_cuts:
-    TT: [600,8500]
-    TE: [600,8500]
-    EE: [600,8500]
-  stop_at_error: true
+    TT: [600,6500]
+    TE: [600,6500]
+    EE: [600,6500]
   params:
     A_act:
       value: "lambda A_planck: A_planck"

--- a/yamls/likelihoods/p_act_lite.yaml
+++ b/yamls/likelihoods/p_act_lite.yaml
@@ -7,15 +7,8 @@ act_dr6_cmbonly.PlanckActCut:
     lmax_cuts: 1000 600 600
   params:
     A_planck:
-      prior:
-        min: 0.5
-        max: 1.5
-      ref:
-        dist: norm
-        loc: 1.0
-        scale: 0.1
-      latex: A_{\rm planck}
-      proposal: 0.003
+      value: "lambda A_act: A_act"
+      latex: A_{\rm Planck}
 
 act_dr6_cmbonly:
   stop_at_error: true
@@ -26,7 +19,14 @@ act_dr6_cmbonly:
     EE: [600,6500]
   params:
     A_act:
-      value: "lambda A_planck: A_planck"
+      prior:
+        min: 0.5
+        max: 1.5
+      ref:
+        dist: norm
+        loc: 1.0
+        scale: 0.1
+      proposal: 0.003
       latex: A_{\rm ACT}
     P_act:
       prior:

--- a/yamls/likelihoods/p_act_lite.yaml
+++ b/yamls/likelihoods/p_act_lite.yaml
@@ -12,29 +12,3 @@ act_dr6_cmbonly.PlanckActCut:
 
 act_dr6_cmbonly:
   stop_at_error: true
-  lmax_theory: 9000
-  ell_cuts:
-    TT: [600,6500]
-    TE: [600,6500]
-    EE: [600,6500]
-  params:
-    A_act:
-      prior:
-        min: 0.5
-        max: 1.5
-      ref:
-        dist: norm
-        loc: 1.0
-        scale: 0.1
-      proposal: 0.003
-      latex: A_{\rm ACT}
-    P_act:
-      prior:
-        min: 0.9
-        max: 1.1
-      ref:
-        dist: norm
-        loc: 1.0
-        scale: 0.01
-      proposal: 0.01
-      latex: p_{\rm ACT}


### PR DESCRIPTION
Addresses #11 along with some minor updates.

- Add default parameter sampling to ACT-lite.
- Set the proper data ellmax = 6500 in the example yaml files.
- Fixed A_planck to A_act for P-ACT instead of other way around (#12).